### PR TITLE
Change formatting

### DIFF
--- a/koscbot/crypto/rates.py
+++ b/koscbot/crypto/rates.py
@@ -15,6 +15,6 @@ async def get_crypto_rates():
     for crypto, rates in json.loads(r.content).items():
         message += crypto + ":\n"
         for currency, rate in rates.items():
-            message += "    " + currency + ": " + str(rate) + "\n"
+            message += "    " + currency + ": " + f"{rate:.2f}" + "\n"
     message += "```"
     return message


### PR DESCRIPTION
Now this response `{"BTC":{"USD":8832.9}}` will be printed as `8832.90`.